### PR TITLE
Version 1.1.0 IAM Identity Center

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/AwsPolicies/AwsPolicyLoader.cs
+++ b/AwsPolicies/AwsPolicyLoader.cs
@@ -45,7 +45,7 @@ namespace AwsAccessGraph.AwsPolicies
                 bool noFiles,
                 CancellationToken cancellationToken)
         {
-            var actualAwsAccountId = new String(awsAccountId);
+            var actualAwsAccountId = new string(awsAccountId);
 
             var stsClientFactory = Globals.GetStsClientFactory(awsAccessKeyId, awsSecretAccessKey, awsSessionToken);
             var iamClientFactory = new Lazy<AmazonIdentityManagementServiceClient>(() =>
@@ -70,7 +70,7 @@ namespace AwsAccessGraph.AwsPolicies
                 // to double-check the account id passed in matches the credential.
                 if (stsClientFactory == null)
                 {
-                    Console.Error.WriteLine($"No AWS credentials were not provided.  Aboring STS client creation.");
+                    Console.Error.WriteLine($"No AWS credentials were not provided.  Aborting STS client creation.");
                     System.Environment.Exit((int)Constants.ExitCodes.AwsAccountIdMissing);
                 }
                 else if (!stsClientFactory.IsValueCreated)
@@ -92,7 +92,7 @@ namespace AwsAccessGraph.AwsPolicies
             {
                 if (stsClientFactory == null)
                 {
-                    Console.Error.WriteLine($"No AWS credentials were not provided.  Aboring STS client creation.");
+                    Console.Error.WriteLine($"No AWS credentials were not provided.  Aborting STS client creation.");
                     System.Environment.Exit((int)Constants.ExitCodes.AwsAccountIdMissing);
                 }
 
@@ -111,7 +111,7 @@ namespace AwsAccessGraph.AwsPolicies
             List<UserDetail>? userList = null;
             List<SAMLProviderListEntry>? samlIdpList = null;
             {
-                Console.WriteLine("Enumerating Account Authorization Details... ");
+                Console.Error.WriteLine("Enumerating Account Authorization Details... ");
                 var groupListPath = () => Path.Combine(outputDirectory, $"aws-{actualAwsAccountId}-group-list.json");
                 var policyListPath = () => Path.Combine(outputDirectory, $"aws-{actualAwsAccountId}-policy-list.json");
                 var roleListPath = () => Path.Combine(outputDirectory, $"aws-{actualAwsAccountId}-role-list.json");
@@ -312,7 +312,7 @@ namespace AwsAccessGraph.AwsPolicies
                             return iam;
                         });
 
-            Console.Write("Enumerating Service Last Action action details... ");
+            Console.Error.WriteLine("Enumerating Service Last Action action details... ");
 
             // Get this for each role.
             var roleJobIds = new Queue<(string RoleId, string JobId)>(roleList.Count);
@@ -323,7 +323,7 @@ namespace AwsAccessGraph.AwsPolicies
                    && File.Exists(roleActionDetailsPath)
                    && (DateTime.UtcNow - File.GetLastWriteTimeUtc(roleActionDetailsPath)).TotalHours < CachedHours)
                 {
-                    iamClient = iamClient ?? iamClientFactory.Value;
+                    iamClient ??= iamClientFactory.Value;
                     do
                     {
                         var response = await iamClient.GenerateServiceLastAccessedDetailsAsync(new GenerateServiceLastAccessedDetailsRequest

--- a/AwsPolicies/PolicyAnalyzer.cs
+++ b/AwsPolicies/PolicyAnalyzer.cs
@@ -29,7 +29,7 @@ namespace AwsAccessGraph.AwsPolicies
             PolicyArn policyArn,
             string policyDocument,
             IEnumerable<RoleDetail> roleList,
-            string? limitToAwsServicePrefix)
+            string[] limitToAwsServicePrefixes)
         {
             AwsPolicy policy;
             try
@@ -96,7 +96,9 @@ namespace AwsAccessGraph.AwsPolicies
                         //if (!Constants.AwsServicePolicyNames.TryGetValue(actionParts[0].ToLowerInvariant(), out string? awsService))
                         //    awsService = $"UNKNOWN {actionParts[0]}";
 
-                        if (limitToAwsServicePrefix == null || string.Compare(actionParts[0], limitToAwsServicePrefix, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (limitToAwsServicePrefixes == null
+                            || !limitToAwsServicePrefixes.Any()
+                            || limitToAwsServicePrefixes.Any(p => string.Compare(actionParts[0], p, StringComparison.OrdinalIgnoreCase) == 0))
                         {
                             stanzas.Add(new PolicyStanza
                             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.1.0 - 2023-12-11
+
+### Added
+
+- New command line argument --aws-profile allows specifying an AWS profile configured in the local environment
+- Support for IAM Identity Center by calling a named profile instead of specifying --aws-access-key-id, --aws-secret-key, or --aws-session-token or requiring those values to be provided in the environment
+
+### Changed
+
+- If refresh-okta is specified and no Okta base URL is provided, quite with an error
+- When running a refresh run over multiple AWS accounts, read Okta data at most one time
+- Minor spelling corrections
+
 ## 1.0.4 - 2023-07-05
 
 ### Changed

--- a/CommandLineOptions.cs
+++ b/CommandLineOptions.cs
@@ -29,7 +29,10 @@ namespace AwsAccessGraph
         [Value(index: 2, MetaName = "Output Path", Required = false, Default = "./output", HelpText = "Path to cache API results for offline processing.")]
         public string OutputPath { get; set; } = "./output";
 
-        [Option("aws-access-key-id", Required = false, HelpText = "If specified, the AWS Acccess Key ID to authenticate to the AWS API.  If this is not specified but a value is present in the environment variable AWS_ACCESS_KEY_ID, that value will be used instead.  If that is not specified either, cached AWS policies will be ignored, and this will be read programmatically using STS get-caller-identity from the supplied credentials.  This value usually begins with AKIA or ASIA")]
+        [Option("aws-profile", Required = false, HelpText = "If specified, the profile name from the AWS config file to use to obtain AWS credentials.  If a profile is specified aws-access-key-id, aws-secret-key, aws-session-token, and aws-account-id arguments are ignored if provided.")]
+        public string? AwsProfileName { get; set; }
+
+        [Option("aws-access-key-id", Required = false, HelpText = "If specified, the AWS Access Key ID to authenticate to the AWS API.  If this is not specified but a value is present in the environment variable AWS_ACCESS_KEY_ID, that value will be used instead.  If that is not specified either, cached AWS policies will be ignored, and this will be read programmatically using STS get-caller-identity from the supplied credentials.  This value usually begins with AKIA or ASIA")]
         public string? AwsAccessKeyId { get; set; }
 
         [Option("aws-secret-key", Required = false, HelpText = "If specified, the AWS Secret Access Key to authenticate to the AWS API.  If this is not specified but a value is present in the environment variable AWS_SECRET_ACCESS_KEY, that value will be used instead.  If that is not specified either, cached AWS policies will be ignored, and this will be read programmatically using STS get-caller-identity from the supplied credentials.")]

--- a/Constants.cs
+++ b/Constants.cs
@@ -377,6 +377,8 @@ namespace AwsAccessGraph
             AwsCredentialsNotSpecified = -5,
             AwsAccountIdMissing = -6,
             TargetServiceNotFound = -7,
+            AwsProfileNotFound = -8,
+            OktaCredentialsNotSpecified = -9,
         }
     }
 }

--- a/GraphBuilder.cs
+++ b/GraphBuilder.cs
@@ -32,7 +32,7 @@ namespace AwsAccessGraph
             IEnumerable<OktaUser> oktaUsers,
             Dictionary<OktaGroupId, OktaGroupMember[]> oktaGroupMembers,
             bool verbose,
-            string? limitToAwsServicePrefix,
+            string[] limitToAwsServicePrefixes,
             bool noPruneUnrelatedNodes,
             bool noIdentities
         )
@@ -42,7 +42,7 @@ namespace AwsAccessGraph
             var policyAnalyses = new Dictionary<PolicyArn, PolicyAnalyzerResult>();
             foreach (var p in awsPolicies)
             {
-                var result = PolicyAnalyzer.Analyze(p.Arn, Uri.UnescapeDataString(p.PolicyVersionList.Single(v => v.VersionId == p.DefaultVersionId).Document), awsRoles, limitToAwsServicePrefix);
+                var result = PolicyAnalyzer.Analyze(p.Arn, Uri.UnescapeDataString(p.PolicyVersionList.Single(v => v.VersionId == p.DefaultVersionId).Document), awsRoles, limitToAwsServicePrefixes);
                 if (!policyAnalyses.TryAdd(p.Arn, result))
                 {
                     // This policy's could have broken across pagination.
@@ -151,7 +151,7 @@ namespace AwsAccessGraph
                         Arn = $"{g.GroupName}/{inlinePolicy.PolicyName}",
                     };
 
-                    var result = PolicyAnalyzer.Analyze(inlinePolicyNode.Arn, Uri.UnescapeDataString(inlinePolicy.PolicyDocument), awsRoles, limitToAwsServicePrefix);
+                    var result = PolicyAnalyzer.Analyze(inlinePolicyNode.Arn, Uri.UnescapeDataString(inlinePolicy.PolicyDocument), awsRoles, limitToAwsServicePrefixes);
 
                     // Add directed edges from this policy to applicable services.
                     var ct2 = 0;
@@ -214,7 +214,7 @@ namespace AwsAccessGraph
                         Arn = $"{r.RoleName}/{inlinePolicy.PolicyName}",
                     };
 
-                    var result = PolicyAnalyzer.Analyze(inlinePolicyNode.Arn, Uri.UnescapeDataString(inlinePolicy.PolicyDocument), awsRoles, limitToAwsServicePrefix);
+                    var result = PolicyAnalyzer.Analyze(inlinePolicyNode.Arn, Uri.UnescapeDataString(inlinePolicy.PolicyDocument), awsRoles, limitToAwsServicePrefixes);
 
                     // Add directed edges from this policy to applicable services.
                     var ct2 = 0;
@@ -292,7 +292,7 @@ namespace AwsAccessGraph
                             Arn = $"{u.UserName}/{inlinePolicy.PolicyName}",
                         };
 
-                        var result = PolicyAnalyzer.Analyze(inlinePolicyNode.Arn, Uri.UnescapeDataString(inlinePolicy.PolicyDocument), awsRoles, limitToAwsServicePrefix);
+                        var result = PolicyAnalyzer.Analyze(inlinePolicyNode.Arn, Uri.UnescapeDataString(inlinePolicy.PolicyDocument), awsRoles, limitToAwsServicePrefixes);
 
                         // Add directed edges from this policy to applicable services.
                         var ct2 = 0;

--- a/OktaPolicies/OktaPolicyLoader.cs
+++ b/OktaPolicies/OktaPolicyLoader.cs
@@ -17,6 +17,7 @@ aws-access-graph. If not, see <https://www.gnu.org/licenses/>.
 using System.Text.Json;
 using Okta.Sdk.Api;
 using Okta.Sdk.Client;
+using Okta.Sdk.Model;
 
 namespace AwsAccessGraph.OktaPolicies
 {
@@ -41,12 +42,12 @@ namespace AwsAccessGraph.OktaPolicies
             // ###################
             var oktaGroupClientFactory = new Lazy<GroupApi?>(() =>
                 {
-                    Console.Write("Getting Okta group API client... ");
+                    Console.Error.Write("Getting Okta group API client... ");
 
                     if (string.IsNullOrWhiteSpace(oktaDomain))
                     {
                         Console.Error.WriteLine("[X]");
-                        Console.Error.WriteLine($"No Okta Base URL (domain) was specified.  Aboring Okta group API client creation.");
+                        Console.Error.WriteLine($"WARNING: No Okta Base URL (domain) was specified.  Aborting Okta group API client creation.");
                         return null;
                     }
 
@@ -87,6 +88,11 @@ namespace AwsAccessGraph.OktaPolicies
                     var oktaGroupClient = oktaGroupClientFactory.Value;
                     if (oktaGroupClient == null)
                     {
+                        if (forceRefresh) {
+                            Console.Error.WriteLine($"ERROR: Okta cannot be refreshed because no Okta Base URL (domain) was specified.");
+                            Environment.Exit((int)Constants.ExitCodes.OktaCredentialsNotSpecified);
+                        }
+
                         Console.Error.WriteLine($"Because no Okta Base URL (domain) was specified, processing will continue without Okta data.");
                         return (
                             Array.Empty<AwsAccessGraph.OktaPolicies.OktaGroup>(),
@@ -112,7 +118,7 @@ namespace AwsAccessGraph.OktaPolicies
             // ##################
             var oktaUserClient = new Lazy<UserApi>(() =>
                 {
-                    Console.Write("Getting Okta user API client... ");
+                    Console.Error.Write("Getting Okta user API client... ");
 
                     var config = new Configuration
                     {

--- a/README.md
+++ b/README.md
@@ -71,16 +71,24 @@ The following is an output of the help screen displaying command line
 arguments:
 
 ```
-AWS Access Graph 1.0.4
+AWS Access Graph 1.1.0
 Copyright (C) 2023 Sean McElroy.  All rights reserved.
 
-  --aws-access-key-id     If specified, the AWS Acccess Key ID to authenticate to the AWS
+  --aws-profile           If specified, the AWS profile configured by this name in the
+                          local environment is used.  This can be used to configure a
+                          profile for AWS IAM Identity Center and will open the SSO window
+                          as needed to obtain credentials.  This is the preferred
+                          authentication mechanism to manually specifying the access key,
+                          secret key, and session token.
+
+  --aws-access-key-id     If specified, the AWS Access Key ID to authenticate to the AWS
                           API.  If this is not specified but a value is present in the
                           environment variable AWS_ACCESS_KEY_ID, that value will be used
                           instead.  If that is not specified either, cached AWS policies
                           will be ignored, and this will be read programmatically using STS
                           get-caller-identity from the supplied credentials.  This value
-                          usually begins with AKIA or ASIA
+                          usually begins with AKIA or ASIA.  Please see --aws-profile for
+                          a better way to specify credentials.
 
   --aws-secret-key        If specified, the AWS Secret Access Key to authenticate to the 
                           AWS API.  If this is not specified but a value is present in the
@@ -88,12 +96,14 @@ Copyright (C) 2023 Sean McElroy.  All rights reserved.
                           used instead.  If that is not specified either, cached AWS 
                           policies will be ignored, and this will be read programmatically
                           using STS get-caller-identity from the supplied credentials.
+                          Please see --aws-profile for a better way to specify credentials.
 
   --aws-session-token     If specified, the AWS Session Token to authenticate to the AWS
                           API.  If this is not specified but a value is present in the
                           environment variable AWS_SESSION_TOKEN, that value will be used
                           instead.  This is only relevant when a temporary session token is
-                          used instead of a static IAM access key.
+                          used instead of a static IAM access key.  Please see 
+                          --aws-profile for a better way to specify credentials.
 
   --aws-account-id        If specified, the account number of the AWS account to analyze.  
                           If this is not specified but a value is present in the environment
@@ -140,6 +150,8 @@ Copyright (C) 2023 Sean McElroy.  All rights reserved.
   --version               Display version information.
 
   Service (pos. 0)        (Default: ec2) AWS service prefix for which to analyze authorizations.
+                          Note, this value can be a comma-delimited list of service prefixes,
+                          such as iam,kms,ec2 to output multiple reports in a single run.
 
   DB Path (pos. 1)        (Default: ./db) Path to cache API results for offline processing.
 

--- a/aws-access-graph.csproj
+++ b/aws-access-graph.csproj
@@ -2,23 +2,25 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>aws_access_graph</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyTitle>AWS Access Graph</AssemblyTitle>
-    <Version>1.0.4</Version>
+    <Version>1.1.0</Version>
     <Authors>Sean McElroy</Authors>
     <Copyright>Copyright (C) 2023 Sean McElroy.  All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.102" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.103.16" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.300.16" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.17" />
+    <PackageReference Include="AWSSDK.SSO" Version="3.7.300.16" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.301.11" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageReference Include="Okta.Sdk" Version="6.0.11" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Okta.Sdk" Version="7.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## 1.1.0 - 2023-12-11

### Added

- New command line argument --aws-profile allows specifying an AWS profile configured in the local environment
- Support for IAM Identity Center by calling a named profile instead of specifying --aws-access-key-id, --aws-secret-key, or --aws-session-token or requiring those values to be provided in the environment